### PR TITLE
More comprehensive .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,28 @@
-*.pyc
+*.py[co]
+
+# Packages
+*.egg
+*.egg-info
+dist
+build
+eggs
+parts
+bin
+var
+sdist
+develop-eggs
+.installed.cfg
+
+# Installer logs
+pip-log.txt
+
+# Unit test / coverage reports
+.coverage
+coverage.xml
+.tox
+
+#Translations
+*.mo
+
+#Mr Developer
+.mr.developer.cfg


### PR DESCRIPTION
Gets rid of stuff like:

```
$ git status
On branch setup_py
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	teamcity_rest_client.egg-info/
```