### PR TITLE
Remove print

### DIFF
--- a/tc.py
+++ b/tc.py
@@ -156,7 +156,6 @@ class TeamCityRESTApiClient:
         :return: the Python dictionary which represents the JSON response.
         """
         full_resource_url = self.compose_resource_path()
-        print full_resource_url
         req = urllib2.Request(full_resource_url)
         base64string = base64.encodestring(self.userpass).replace('\n', '')
         req.add_header("Authorization", "Basic %s" % base64string)


### PR DESCRIPTION
Not Python 3 compatible and probably library code shouldn't have a `print` anyway.
