### PR TITLE
iteritems => items for py3 compat

### DIFF
--- a/tc.py
+++ b/tc.py
@@ -134,13 +134,13 @@ class TeamCityRESTApiClient:
         if self.locators:
             locators = 'locator=' + ','.join([
                 "%s:%s" % (k, v)
-                for k, v in self.locators.iteritems()
+                for k, v in self.locators.items()
             ])
         else:
             locators = ''
         get_args = '&'.join([locators] + [
             '%s=%s' % (k, v)
-            for k, v in self.parameters.iteritems()
+            for k, v in self.parameters.items()
         ])
         if get_args:
             full_resource_url = full_resource_url + '?' + get_args


### PR DESCRIPTION
With this and #7, I can get it to work on Python 3.4.

```
[marca@marca-mac2 teamcity-python-rest-client]$ git branch
  add_sample
  gitignore
  iteritems_to_items
  master
* msabramo_master
  py3
  remove_print
  setup_py
  tox
  use_requests

[marca@marca-mac2 teamcity-python-rest-client]$ git log -n 1
commit bf0c2018bb7100fe9201e9a2af6d88b9ff1df031
Author: Marc Abramowitz <marc@marc-abramowitz.com>
Date:   Tue Feb 24 12:39:55 2015 -0800

    iteritems => items for py3 compat

[marca@marca-mac2 teamcity-python-rest-client]$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  py33: commands succeeded
  py34: commands succeeded
  congratulations :)
```
