### PR TITLE
__init__ can get default params from env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,12 +14,29 @@ There you can add the folder to the current selected interpreter, which will mak
 
 ## Examples
 
-### Get all projects in server
+### Connect to server
 
-```language-python
+```python
 # This initialises the Client with the settings passed. <port> has to be an integer.
 client = TeamCityRESTApiClient('account', 'password', 'server', <port>)
+```
 
+or specify no parameters and it will read settings from environment
+variables:
+
+- `TEAMCITY_USER`
+- `TEAMCITY_PASSWORD`
+- `TEAMCITY_HOST`
+- `TEAMCITY_PORT` (Defaults to 80 if not set)
+
+```python
+# Initialises with environment variables: TEAMCITY_{USER,PASSWORD,HOST,PORT}
+client = TeamCityRESTApiClient()
+```
+
+### Get all projects in server
+
+```python
 # Specify the resource type we are going to get, in this case <projects>
 client.get_all_projects()
 

--- a/sample.py
+++ b/sample.py
@@ -3,11 +3,6 @@ import os
 
 from teamcityrestapiclient import TeamCityRESTApiClient
 
-user = os.getenv('TEAMCITY_USER')
-password = os.getenv('TEAMCITY_PASSWORD')
-host = os.getenv('TEAMCITY_HOST')
-port = int(os.getenv('TEAMCITY_PORT'))
-
-tc = TeamCityRESTApiClient(user, password, host, port)
+tc = TeamCityRESTApiClient()
 tc.get_server_info()
 print(json.dumps(tc.get_from_server(), indent=4))

--- a/tc.py
+++ b/tc.py
@@ -3,15 +3,20 @@ RESTful api definition: http://${TeamCity}/guestAuth/app/rest/application.wadl
 """
 
 import json
+import os
 import urllib2
 import base64
 from datetime import datetime, timedelta
 
 
 class TeamCityRESTApiClient:
-    def __init__(self, username, password, server, port):
-        self.TC_REST_URL = "http://%s:%d/httpAuth/app/rest/" % (server, port)
-        self.userpass = '%s:%s' % (username, password)
+    def __init__(self, username=None, password=None, server=None, port=None):
+        self.username = username or os.getenv('TEAMCITY_USER')
+        self.password = password or os.getenv('TEAMCITY_PASSWORD')
+        self.userpass = '%s:%s' % (self.username, self.password)
+        self.host = server or os.getenv('TEAMCITY_HOST')
+        self.port = port or int(os.getenv('TEAMCITY_PORT', 0)) or 80
+        self.TC_REST_URL = "http://%s:%d/httpAuth/app/rest/" % (self.host, self.port)
         self.locators = {}
         self.parameters = {}
 


### PR DESCRIPTION
- `TEAMCITY_USER`
- `TEAMCITY_PASSWORD`
- `TEAMCITY_HOST`
- `TEAMCITY_PORT`

```
$ python sample.py
{
    "userGroups": {
        "href": "/httpAuth/app/rest/userGroups"
    },
    "vcsRoots": {
        "href": "/httpAuth/app/rest/vcs-roots"
    },
    "version": "9.0.2 (build 32195)",
    "internalId": "7a775607-5420-4a17-86a1-543d755d7210",
    "currentTime": "20150224T141500-0800",
    "agentPools": {
        "href": "/httpAuth/app/rest/agentPools"
    },
    "versionMajor": 9,
    "buildNumber": "32195",
    "versionMinor": 0,
    "agents": {
        "href": "/httpAuth/app/rest/agents"
    },
    "startTime": "20150223T105439-0800",
    "builds": {
        "href": "/httpAuth/app/rest/builds"
    },
    "users": {
        "href": "/httpAuth/app/rest/users"
    },
    "buildQueue": {
        "href": "/httpAuth/app/rest/buildQueue"
    },
    "projects": {
        "href": "/httpAuth/app/rest/projects"
    },
    "buildDate": "20150130T000000-0800"
}
```
